### PR TITLE
Add support for globbing matches.

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,10 +31,15 @@ function paramify(url) {
       return false
     }
 
-    var params = {}
+    var params = []
 
-    for (var i = 0; i < reg.keys.length; i++) {
-      params[reg.keys[i].name] = matches[i + 1]
+    for (var i = 0; i < matches.length; i++) {
+      var key = reg.keys[i - 1]
+      if (key) {
+        params[key.name] = matches[i]
+      } else {
+        params.push(matches[i])
+      }
     }
 
     match.params = params

--- a/test/paramify.js
+++ b/test/paramify.js
@@ -1,15 +1,30 @@
 var paramify = require('..')
 var test = require('tape')
 
-test('paramify', function (t) {
-  t.plan(4)
-  var match
+test('single named param', function (t) {
+  t.plan(2)
 
-  match = paramify('/intro/ohai')
+  var match = paramify('/intro/ohai')
   t.assert(match('intro/:greeting'))
-  t.deepEquals(match.params, { greeting: 'ohai' })
+  t.equal(match.params.greeting, 'ohai')
+})
 
-  match = paramify('/showtimes/1337/7331')
+
+test('multiple named params', function (t) {
+  t.plan(3)
+
+  var match = paramify('/showtimes/1337/7331')
   t.assert(match('showtimes/:start/:end'))
-  t.deepEquals(match.params, { start: '1337', end: '7331' })
+  t.equal(match.params.start, '1337')
+  t.equal(match.params.end, '7331')
+})
+
+test('globbing matches', function (t) {
+  t.plan(4)
+
+  var match = paramify('/files/mydir/path/to/file.txt')
+  t.assert(match('/files/:root/*'))
+  t.equal(match.params.root, 'mydir')
+  t.equal(match.params[0], '/files/mydir/path/to/file.txt')
+  t.equal(match.params[1], 'path/to/file.txt')
 })


### PR DESCRIPTION
For cases where you have variable number of url `/` components, the `*` feature from `path-to-regexp` is pretty handy. 

e.g.  
`files/*` will match:
`/files/my/dir/something.txt` and
`/files/some/other/dir/something.txt`

but `paramify` does not currently provide any access to the unnamed matches :cry:

This PR provides access to the unnamed matches as numeric indices on `match.params`:

``` js
var match = paramify('/files/mydir/path/to/file.txt')
match('/files/:root/*')
match.params.root // => 'mydir'
match.params[0] // => '/files/mydir/path/to/file.txt'
match.params[1] // => 'path/to/file.txt'
```
