### PR TITLE
allow regexes to pass through

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,16 +3,18 @@ var pathToRegexp = require('path-to-regexp')
 var cache = {}
 
 function regify(vurl) {
+  var re = vurl instanceof RegExp
+  var key = re ? '$$' + vurl.source : vurl
 
-  if (cache[vurl]) {
-    return cache[vurl]
+  if (cache[key]) {
+    return cache[key]
   }
 
-  if (vurl.charAt(0) != '/') {
+  if (!re && vurl.charAt(0) != '/') {
     vurl = '/' + vurl
   }
 
-  var reg = cache[vurl] = {}
+  var reg = cache[key] = {}
   reg.keys = []
   reg.exp = pathToRegexp(vurl, reg.keys)
 

--- a/test/paramify.js
+++ b/test/paramify.js
@@ -27,3 +27,16 @@ test('globbing matches', function (t) {
   t.equal(match.params.root, 'mydir')
   t.equal(match.params[0], 'path/to/file.txt')
 })
+
+test('regex matches', function (t) {
+  t.plan(3)
+
+  var match = paramify('/files/mydir/path/to/file.txt')
+  t.assert(match(/^\/files(\/.*)?/))
+
+  match = paramify('/files')
+  t.assert(match(/^\/files(\/.*)?/))
+
+  match = paramify('/file')
+  t.assert(!match(/^\/files(\/.*)?/))
+})


### PR DESCRIPTION
path-to-regex allows strings, regexes and arrays, this PR simply adds support for passing regexes through (not interested in array support atm).
