### PR TITLE
add decodeURIComponent

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,6 +23,7 @@ function regify(vurl) {
 
 function paramify(url) {
   try { url = decodeURI(url) } catch($) {}
+  try { url = decodeURIComponent(url) } catch($) {}
 
   function match (vurl) {
 

--- a/test/paramify.js
+++ b/test/paramify.js
@@ -50,3 +50,12 @@ test('regex fail to match', function (t) {
   match = paramify('/@username')
   t.assert(!match(/^\/(xprofile|@#(.*?))/))
 })
+
+test('encoded paths', function(t) {
+  t.plan(3)
+  
+  var match = paramify('/@example%2ftest')
+  t.assert(match('/@:first/:second'))
+  t.equal(match.params.first, 'example')
+  t.equal(match.params.second, 'test')
+})


### PR DESCRIPTION
 decodeURI by itself does not always catch the path when performing a URI decode. Adding `decodeURIComponent` results in more consistent URI decode