### PR TITLE
add description to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "paramify",
   "version": "0.1.2",
-  "description": "",
+  "description": "Parameterized routes without a big bloated router, e.g. 'showtimes/:start/:end' and 'files/*'",
   "main": "index.js",
   "scripts": {
     "test": "tape test/*.js"


### PR DESCRIPTION
this info is exposed on yarnpkg.com, npmjs.com and others. If it's not filled in, the first part of the readme is used (which causes duplication of the codeship badge)